### PR TITLE
Limpiar salida

### DIFF
--- a/ssl-cert-expiration-checker.sh
+++ b/ssl-cert-expiration-checker.sh
@@ -44,7 +44,7 @@ check_ssl_cert(){
     while read site;do
         sitename=$(echo $site | cut -d ":" -f1)
         certificate_last_day=$(echo | openssl s_client -connect ${site} 2>/dev/null | \
-        openssl x509 -noout -enddate | cut -d "=" -f2)
+        openssl x509 -noout -enddate 2>/dev/null | cut -d "=" -f2)
         end_date=$(date +%s -d "$certificate_last_day")
         days_left=$(((end_date - current_date) / 86400))
 


### PR DESCRIPTION
Buenas.

He realizado un pequeño cambio para que no salga por pantalla errores al verificar un certificado caducado.

Gracias por la aportación.