### PR TITLE
Allow vars to be changed from outside script

### DIFF
--- a/jota-cert-checker.sh
+++ b/jota-cert-checker.sh
@@ -14,15 +14,15 @@
 #
 
 sites_list="$1"
-sitename=""
-html_file="certs_check.html"
-img_file="certs_check.jpg"
+sitename="${sitename:-}"
+html_file="${html_file:-certs_check.html}"
+img_file="${img_file:-certs_check.jpg}"
 current_date=$(date +%s)
-end_date=""
-days_left=""
-certificate_last_day=""
-warning_days="300"
-alert_days="150"
+end_date="${end_date:-}"
+days_left="${days_left:-}"
+certificate_last_day="${certificate_last_day:-}"
+warning_days="${warning_days:-300}"
+alert_days="${alert_days:-150}"
 # Terminal colors
 ok_color="\e[38;5;40m"
 warning_color="\e[38;5;220m"
@@ -30,7 +30,7 @@ alert_color="\e[38;5;208m"
 expired_color="\e[38;5;196m"
 end_of_color="\033[0m"
 # Slack
-slack_token="your_slack_token"
+slack_token="${slack_token:-your_slack_token}"
 
 #
 # FUNCTIONS


### PR DESCRIPTION
This will allow modifying the vars without modifying the script. If the variable is not modified, the value following the `-` char will be used as the default. The current defaults have been maintained.

```bash
$ html_file=../test.html ./jota-cert-checker.sh -f sitelist -o html
$ ls ../test.html
../test.html
```

See: https://stackoverflow.com/a/4609718/2965993